### PR TITLE
Fixes Issue #4, stack overflow caused by cyclical cred references

### DIFF
--- a/state/credential.go
+++ b/state/credential.go
@@ -52,15 +52,20 @@ func (c *Credential) PendingDeploys() Deployments {
 }
 
 func (c *Credential) Active() bool {
+	var emptyList Credentials = make(Credentials, 0)
+	return c.ActiveAndNotSeenBefore(emptyList)
+}
+
+func (c *Credential) ActiveAndNotSeenBefore(credsSeen Credentials) bool {
 	if len(c.Deployments) != 0 {
 		return true
 	}
+	if credsSeen.Includes(c) {
+		return false
+	}
+	seen := append(credsSeen, c)
 	for _, cred := range c.ReferencedBy {
-		if cred == c {
-			// Handle circular references
-			continue
-		}
-		if cred.Active() {
+		if cred.ActiveAndNotSeenBefore(seen) {
 			return true
 		}
 	}

--- a/state/credential.go
+++ b/state/credential.go
@@ -56,6 +56,10 @@ func (c *Credential) Active() bool {
 		return true
 	}
 	for _, cred := range c.ReferencedBy {
+		if cred == c {
+			// Handle circular references
+			continue
+		}
 		if cred.Active() {
 			return true
 		}


### PR DESCRIPTION
I've validated that this PR fixes #4 in which cyclical credential references caused credential.Active() to infinitely call itself recursively until SO.

I do not know why the Credhub in question contained cyclical references in the first place, or whether there is a good reason for this to occur. Thoughts welcome. 
