### PR TITLE
Add types flag for rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ List CredHub credentials augmented with information from the BOSH director:
 carousel list [flags]
 
 Flags:
-  -d, --deployments strings   filter by deployment names (comma sperated)
+  -d, --deployments strings   filter by deployment names (comma separated)
   -h, --help                  help for list
 	  --include-all           also show unused credential versions
 	  --signing               only show Certificates used to sign

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -124,7 +124,7 @@ func (f credentialFilters) Filters() []Filter {
 
 func addTypesFlag(set *pflag.FlagSet) {
 	set.StringSliceVarP(&filters.types, "types", "t", ccredhub.CredentialTypeStringValues(),
-		"filter by credential type (comma sperated)")
+		"filter by credential type (comma separated)")
 }
 
 func addDeploymentFlag(set *pflag.FlagSet) {

--- a/cmd/rotate.go
+++ b/cmd/rotate.go
@@ -131,4 +131,5 @@ func init() {
 	addIgnoreUpdateModeCireteriaFlag(rotateCmd.Flags())
 	addNameFlag(rotateCmd.Flags())
 	addDeploymentFlag(rotateCmd.Flags())
+	addTypesFlag(rotateCmd.Flags())
 }


### PR DESCRIPTION
Added types flag so that you may specify to rotate 
```
-t, --types strings           filter by credential type (comma separated) (default [certificate,ssh,rsa,password,user,value,json])
```

or as an example:
```
./carousel rotate --ignore-update-mode --expires-within=1y --types=certificate
```
and this would rotate certs that expire within 1 year. 

**Reason:**
Prior to this ability to specify certificates, just using
```
./carousel rotate --ignore-update-mode --expires-within=1y
```
would have rotated `passwords` that were not in need of rotation if they were created on a certain date.